### PR TITLE
Travis CI: build with local activator script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: scala
 scala:
    - 2.11.5
-script: sbt test
+
+before_script: unset SBT_OPTS JVM_OPTS
+script: ./activator test
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Note that we unset sbt-extras environment variables (SBT_OPTS and
JVM_OPTS) to avoid conflicts with activator sbt wrapper script.

This change resolve travis-ci/travis-ci#3140.